### PR TITLE
Fix verification error & handle passing errors

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -39,10 +39,10 @@ Specifications:
 	- uses ECDSA P-521 (FIPS 186-3) aka. secp521r1
 `,
 	Args: cobra.NoArgs,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return validateNameAndIP(true)
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := validateNameAndIP(true); err != nil {
-			return err
-		}
 		return internal.NewTLSSelfAuthority("gostd", names, ips, outDir)
 	},
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -39,10 +39,10 @@ Specifications:
 	- uses ECDSA P-521 (FIPS 186-3) aka. secp521r1
 `,
 	Args: cobra.NoArgs,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		validateNameAndIP(true)
-	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateNameAndIP(true); err != nil {
+			return err
+		}
 		return internal.NewTLSSelfAuthority("gostd", names, ips, outDir)
 	},
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -35,10 +35,10 @@ confiar will automatically parse the information from the given certificate.
 
 You can pass additional --fqdn or --ip for hostnames which were not included
 in the certificate.`,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return validateNameAndIP(true)
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := validateNameAndIP(false); err != nil {
-			return err
-		}
 		return internal.InstallTLS(certSrc, installTarget, names, ips)
 	},
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -35,10 +35,10 @@ confiar will automatically parse the information from the given certificate.
 
 You can pass additional --fqdn or --ip for hostnames which were not included
 in the certificate.`,
-	PreRun: func(*cobra.Command, []string) {
-		validateNameAndIP(false)
-	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateNameAndIP(false); err != nil {
+			return err
+		}
 		return internal.InstallTLS(certSrc, installTarget, names, ips)
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -102,14 +102,12 @@ var ipList string
 var names []string
 var ips []string
 
-// TODO: return error and let each subcommand deal with the error themselves
-func validateNameAndIP(required bool) {
+func validateNameAndIP(required bool) error {
 	if nameList != "" {
 		names = strings.Split(nameList, ",")
 		for _, name := range names {
 			if !internal.ValidFQDN(name) {
-				fmt.Fprintf(os.Stderr, "Error: \"%v\" is not a valid fully qualified domain name (FQDN)\n", name)
-				os.Exit(1)
+				return fmt.Errorf("\"%v\" is not a valid fully qualified domain name (FQDN)", name)
 			}
 		}
 	}
@@ -117,14 +115,14 @@ func validateNameAndIP(required bool) {
 		ips = strings.Split(ipList, ",")
 		for _, ip := range ips {
 			if !internal.ValidIPAddr(ip) {
-				fmt.Fprintf(os.Stderr, "Error: \"%v\" is not a valid IP address\n", ip)
-				os.Exit(1)
+				return fmt.Errorf("\"%v\" is not a valid IP address", ip)
 			}
 		}
 	}
 	if required && nameList == "" && ipList == "" {
 		// both nameList and ipList are empty string
-		fmt.Fprintf(os.Stderr, "Error: --fqdn and --ip cannot both be blank\n")
-		os.Exit(1)
+		return fmt.Errorf("--fqdn and --ip cannot both be blank")
 	}
+
+	return nil
 }

--- a/internal/cryptographer/gostd.go
+++ b/internal/cryptographer/gostd.go
@@ -114,7 +114,8 @@ func (g *GoStd) NewTLSSelfAuthority(names []string, ips []string, outDir string)
 
 	writeWaiter.Wait()
 
-	for _, filename := range []string{certFileName, keyFileName} {
+	for _, relFilename := range []string{certFileName, keyFileName} {
+		filename := path.Join(outDir, relFilename)
 		if _, err := os.Stat(filename); err != nil {
 			log.Fatal().Err(err).Str("filename", filename).Msg("filestat error")
 		}

--- a/internal/cryptographer/gostd.go
+++ b/internal/cryptographer/gostd.go
@@ -44,6 +44,12 @@ type GoStd struct {
 func (g *GoStd) NewTLSSelfAuthority(names []string, ips []string, outDir string) error {
 	log.Info().Strs("names", names).Strs("ips", ips).Str("outDir", outDir).Send()
 	g.outDir = outDir
+	if outDir != "" {
+		if err := os.MkdirAll(outDir, os.ModePerm); err != nil {
+			log.Fatal().Err(err).Msg("failed to create outDir")
+		}
+	}
+
 	priv, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to generate private key")


### PR DESCRIPTION
## Handling out-dir

original
```
confiar on 🌱main [?] via 🐹 v1.17.2
➜ ./confiar generate --out-dir=p --fqdn=example.com
2022-03-05T07:50:35Z INF  ips=[] names=["example.com"] outDir=p
2022-03-05T07:50:35Z INF certificate valid lifetime validFrom=2022-03-04T22:50:35-08:00 validUntil=2023-03-04T23:50:35-08:00
2022-03-05T07:50:35Z FTL writing file error="failed to create file: open p/key.pem: no such file or directory" filename=key.pem
```

original
```
confiar on 🌱main [?] via 🐹 v1.17.2
➜ ./confiar generate --out-dir=p --fqdn=example.com
2022-03-05T07:44:20Z INF  ips=[] names=["example.com"] outDir=p
2022-03-05T07:44:20Z INF certificate valid lifetime validFrom=2022-03-04T22:44:20-08:00 validUntil=2023-03-04T23:44:20-08:00
2022-03-05T07:44:20Z INF wrote file filename=key.pem
2022-03-05T07:44:20Z INF wrote file filename=cert.pem
2022-03-05T07:44:20Z FTL filestat error error="stat cert.pem: no such file or directory" filename=cert.pem
```

fork
```
confiar-fork on 🌱main [!?] via 🐹 v1.17.2
➜ ./confiar generate --out-dir=p --fqdn=example.com
2022-03-05T07:49:09Z INF  ips=[] names=["example.com"] outDir=p
2022-03-05T07:49:09Z INF certificate valid lifetime validFrom=2022-03-04T22:49:09-08:00 validUntil=2023-03-04T23:49:09-08:00
2022-03-05T07:49:09Z INF wrote file filename=key.pem
2022-03-05T07:49:09Z INF wrote file filename=cert.pem
```


## Error Handling

original
```
confiar on 🌱main [?] via 🐹 v1.17.2
➜ ./confiar generate --out-dir=p
Error: --fqdn and --ip cannot both be blank
```

fork
```
confiar-fork on 🌱main [?] via 🐹 v1.17.2
➜ ./confiar generate --out-dir=p
Error: --fqdn and --ip cannot both be blank
Usage:
  confiar generate [flags]

Flags:
      --fqdn string      domain name(s) for certificate (comma separated)
  -h, --help             help for generate
      --ip string        IP address(es) for certificate (comma separated)
      --out-dir string   directory where certificate will be written to (default ".")

Global Flags:
      --debug   toggle debug logs
      --json    print logs as json

--fqdn and --ip cannot both be blank
```